### PR TITLE
Stop redundant `set`s

### DIFF
--- a/src/setValueFunctions.php
+++ b/src/setValueFunctions.php
@@ -95,5 +95,8 @@ function setValueByArrayPath($doc, $fieldPath, $value) {
     $fieldName = array_shift($fieldPath);
     $subDoc = getValue($doc, $fieldName, array());
     $subDocUpdated = setValueByArrayPath($subDoc, $fieldPath, $value);
-    return setValue($doc, $fieldName, $subDocUpdated);
+    if ($subDocUpdated !== $subDoc) {
+        $doc = setValue($doc, $fieldName, $subDocUpdated);
+    }
+    return $doc;
 }


### PR DESCRIPTION
I noticed that `setValueByArrayPath` blindly called `setValue` when winding up its recursion, which is both inefficient and caused unwanted side effects on objects. I've added a check that ensures that the function is only called when there's something to set. Because I'm using strict equality, we basically only exclude situations where `$subDoc` is an object (which is my goal).
