### PR TITLE
PHP 7.4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,5 @@ language: php
 install:
   composer install
 php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
+  - 7.1
+  - 7.4

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,29 @@
 {
-    "name": "revinate/php-getter-setter",
-    "description": "PHP library to simplify getting and setting values in arrays and objects.",
-    "autoload": {
-        "psr-4": {
-            "Revinate\\GetterSetter\\": "src",
-            "Revinate\\GetterSetter\\test\\": "test"
-        },
-        "files": [ "src/getValueFunctions.php", "src/setValueFunctions.php", "src/util/utils.php" ]
+  "name": "revinate/php-getter-setter",
+  "description": "PHP library to simplify getting and setting values in arrays and objects.",
+  "autoload": {
+    "psr-4": {
+      "Revinate\\GetterSetter\\": "src",
+      "Revinate\\GetterSetter\\test\\": "test"
     },
-    "require": {
-        "php": ">=5.3.3"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^4.8"
-    },
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Jason Dent",
-            "email": "jason@revinate.com"
-        }
+    "files": [
+      "src/getValueFunctions.php",
+      "src/setValueFunctions.php",
+      "src/util/utils.php"
     ]
+  },
+  "require": {
+    "php": ">=7",
+    "ext-json": "*"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^6"
+  },
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Jason Dent",
+      "email": "jason@revinate.com"
+    }
+  ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,972 +1,1539 @@
 {
-    "_readme": [
-        "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
-        "This file is @generated automatically"
-    ],
-    "hash": "284f2bb4065e4de6adf385ff938b29dd",
-    "content-hash": "7da0a1499b1fcf9e9cc83f8bc7700873",
-    "packages": [],
-    "packages-dev": [
-        {
-            "name": "doctrine/instantiator",
-            "version": "1.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3,<8.0-DEV"
-            },
-            "require-dev": {
-                "athletic/athletic": "~0.1.8",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "time": "2015-06-14 21:17:01"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
-                }
-            ],
-            "time": "2015-02-03 12:10:50"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "v1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4745ded9307786b730d7a60df5cb5a6c43cf95f7",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "~2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "time": "2015-08-13 10:07:40"
-        },
-        {
-            "name": "phpunit/php-code-coverage",
-            "version": "2.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef1ca6835468857944d5c3b48fa503d5554cff2f",
-                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
-            },
-            "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
-            },
-            "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
-            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
-            "keywords": [
-                "coverage",
-                "testing",
-                "xunit"
-            ],
-            "time": "2015-09-14 06:51:16"
-        },
-        {
-            "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
-            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
-            "keywords": [
-                "filesystem",
-                "iterator"
-            ],
-            "time": "2015-06-21 13:08:43"
-        },
-        {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Simple template engine.",
-            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
-            "keywords": [
-                "template"
-            ],
-            "time": "2015-06-21 13:50:34"
-        },
-        {
-            "name": "phpunit/php-timer",
-            "version": "1.0.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Utility class for timing",
-            "homepage": "https://github.com/sebastianbergmann/php-timer/",
-            "keywords": [
-                "timer"
-            ],
-            "time": "2015-06-21 08:01:12"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "1.4.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3ab72c62e550370a6cd5dc873e1a04ab57562f5b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3ab72c62e550370a6cd5dc873e1a04ab57562f5b",
-                "reference": "3ab72c62e550370a6cd5dc873e1a04ab57562f5b",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "time": "2015-08-16 08:51:00"
-        },
-        {
-            "name": "phpunit/phpunit",
-            "version": "4.8.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "dab2ada9e9a503d2ec3c32fe0fb59dea9bdd9dfa"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/dab2ada9e9a503d2ec3c32fe0fb59dea9bdd9dfa",
-                "reference": "dab2ada9e9a503d2ec3c32fe0fb59dea9bdd9dfa",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": ">=1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
-            },
-            "suggest": {
-                "phpunit/php-invoker": "~1.1"
-            },
-            "bin": [
-                "phpunit"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.8.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "The PHP Unit Testing framework.",
-            "homepage": "https://phpunit.de/",
-            "keywords": [
-                "phpunit",
-                "testing",
-                "xunit"
-            ],
-            "time": "2015-09-14 06:57:22"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "5e2645ad49d196e020b85598d7c97e482725786a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5e2645ad49d196e020b85598d7c97e482725786a",
-                "reference": "5e2645ad49d196e020b85598d7c97e482725786a",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.4"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "time": "2015-08-19 09:14:08"
-        },
-        {
-            "name": "sebastian/comparator",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
-            "keywords": [
-                "comparator",
-                "compare",
-                "equality"
-            ],
-            "time": "2015-07-26 15:48:44"
-        },
-        {
-            "name": "sebastian/diff",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/863df9687835c62aa423a22412d26fa2ebde3fd3",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "http://www.github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff"
-            ],
-            "time": "2015-02-22 15:13:53"
-        },
-        {
-            "name": "sebastian/environment",
-            "version": "1.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
-            "keywords": [
-                "Xdebug",
-                "environment",
-                "hhvm"
-            ],
-            "time": "2015-08-03 06:14:51"
-        },
-        {
-            "name": "sebastian/exporter",
-            "version": "1.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
-            "keywords": [
-                "export",
-                "exporter"
-            ],
-            "time": "2015-06-21 07:55:53"
-        },
-        {
-            "name": "sebastian/global-state",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
-                "reference": "c7428acdb62ece0a45e6306f1ae85e1c05b09c01",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.2"
-            },
-            "suggest": {
-                "ext-uopz": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
-            "keywords": [
-                "global state"
-            ],
-            "time": "2014-10-06 09:23:50"
-        },
-        {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-06-21 08:04:50"
-        },
-        {
-            "name": "sebastian/version",
-            "version": "1.0.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "shasum": ""
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
-            "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v2.7.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/Yaml.git",
-                "reference": "2dc7b06c065df96cc686c66da2705e5e18aef661"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/2dc7b06c065df96cc686c66da2705e5e18aef661",
-                "reference": "2dc7b06c065df96cc686c66da2705e5e18aef661",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2015-08-24 07:13:45"
+  "_readme": [
+    "This file locks the dependencies of your project to a known state",
+    "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+    "This file is @generated automatically"
+  ],
+  "content-hash": "6975bec6ee746702f0393bf74fafd656",
+  "packages": [],
+  "packages-dev": [
+    {
+      "name": "doctrine/instantiator",
+      "version": "1.3.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/doctrine/instantiator.git",
+        "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
+        "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.1"
+      },
+      "require-dev": {
+        "doctrine/coding-standard": "^6.0",
+        "ext-pdo": "*",
+        "ext-phar": "*",
+        "phpbench/phpbench": "^0.13",
+        "phpstan/phpstan-phpunit": "^0.11",
+        "phpstan/phpstan-shim": "^0.11",
+        "phpunit/phpunit": "^7.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.2.x-dev"
         }
-    ],
-    "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": [],
-    "prefer-stable": false,
-    "prefer-lowest": false,
-    "platform": {
-        "php": ">=5.3.3"
+      },
+      "autoload": {
+        "psr-4": {
+          "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Marco Pivetta",
+          "email": "ocramius@gmail.com",
+          "homepage": "http://ocramius.github.com/"
+        }
+      ],
+      "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+      "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+      "keywords": [
+        "constructor",
+        "instantiate"
+      ],
+      "time": "2019-10-21T16:45:58+00:00"
     },
-    "platform-dev": []
+    {
+      "name": "myclabs/deep-copy",
+      "version": "1.9.5",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/myclabs/DeepCopy.git",
+        "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
+        "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.1"
+      },
+      "replace": {
+        "myclabs/deep-copy": "self.version"
+      },
+      "require-dev": {
+        "doctrine/collections": "^1.0",
+        "doctrine/common": "^2.6",
+        "phpunit/phpunit": "^7.1"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "DeepCopy\\": "src/DeepCopy/"
+        },
+        "files": [
+          "src/DeepCopy/deep_copy.php"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "description": "Create deep copies (clones) of your objects",
+      "keywords": [
+        "clone",
+        "copy",
+        "duplicate",
+        "object",
+        "object graph"
+      ],
+      "time": "2020-01-17T21:11:47+00:00"
+    },
+    {
+      "name": "phar-io/manifest",
+      "version": "1.0.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/phar-io/manifest.git",
+        "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+        "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+        "shasum": ""
+      },
+      "require": {
+        "ext-dom": "*",
+        "ext-phar": "*",
+        "phar-io/version": "^1.0.1",
+        "php": "^5.6 || ^7.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.0.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Arne Blankerts",
+          "email": "arne@blankerts.de",
+          "role": "Developer"
+        },
+        {
+          "name": "Sebastian Heuer",
+          "email": "sebastian@phpeople.de",
+          "role": "Developer"
+        },
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de",
+          "role": "Developer"
+        }
+      ],
+      "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+      "time": "2017-03-05T18:14:27+00:00"
+    },
+    {
+      "name": "phar-io/version",
+      "version": "1.0.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/phar-io/version.git",
+        "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+        "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^5.6 || ^7.0"
+      },
+      "type": "library",
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Arne Blankerts",
+          "email": "arne@blankerts.de",
+          "role": "Developer"
+        },
+        {
+          "name": "Sebastian Heuer",
+          "email": "sebastian@phpeople.de",
+          "role": "Developer"
+        },
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de",
+          "role": "Developer"
+        }
+      ],
+      "description": "Library for handling version information and constraints",
+      "time": "2017-03-05T17:38:23+00:00"
+    },
+    {
+      "name": "phpdocumentor/reflection-common",
+      "version": "2.0.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+        "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+        "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "~6"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "phpDocumentor\\Reflection\\": "src/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Jaap van Otterdijk",
+          "email": "opensource@ijaap.nl"
+        }
+      ],
+      "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+      "homepage": "http://www.phpdoc.org",
+      "keywords": [
+        "FQSEN",
+        "phpDocumentor",
+        "phpdoc",
+        "reflection",
+        "static analysis"
+      ],
+      "time": "2018-08-07T13:53:10+00:00"
+    },
+    {
+      "name": "phpdocumentor/reflection-docblock",
+      "version": "4.3.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+        "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/da3fd972d6bafd628114f7e7e036f45944b62e9c",
+        "reference": "da3fd972d6bafd628114f7e7e036f45944b62e9c",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.0",
+        "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
+        "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
+        "webmozart/assert": "^1.0"
+      },
+      "require-dev": {
+        "doctrine/instantiator": "^1.0.5",
+        "mockery/mockery": "^1.0",
+        "phpdocumentor/type-resolver": "0.4.*",
+        "phpunit/phpunit": "^6.4"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "4.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "phpDocumentor\\Reflection\\": [
+            "src/"
+          ]
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Mike van Riel",
+          "email": "me@mikevanriel.com"
+        }
+      ],
+      "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+      "time": "2019-12-28T18:55:12+00:00"
+    },
+    {
+      "name": "phpdocumentor/type-resolver",
+      "version": "1.0.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/phpDocumentor/TypeResolver.git",
+        "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+        "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.1",
+        "phpdocumentor/reflection-common": "^2.0"
+      },
+      "require-dev": {
+        "ext-tokenizer": "^7.1",
+        "mockery/mockery": "~1",
+        "phpunit/phpunit": "^7.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "phpDocumentor\\Reflection\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Mike van Riel",
+          "email": "me@mikevanriel.com"
+        }
+      ],
+      "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+      "time": "2019-08-22T18:11:29+00:00"
+    },
+    {
+      "name": "phpspec/prophecy",
+      "version": "v1.10.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/phpspec/prophecy.git",
+        "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
+        "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
+        "shasum": ""
+      },
+      "require": {
+        "doctrine/instantiator": "^1.0.2",
+        "php": "^5.3|^7.0",
+        "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+        "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+        "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+      },
+      "require-dev": {
+        "phpspec/phpspec": "^2.5 || ^3.2",
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.10.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Prophecy\\": "src/Prophecy"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Konstantin Kudryashov",
+          "email": "ever.zet@gmail.com",
+          "homepage": "http://everzet.com"
+        },
+        {
+          "name": "Marcello Duarte",
+          "email": "marcello.duarte@gmail.com"
+        }
+      ],
+      "description": "Highly opinionated mocking framework for PHP 5.3+",
+      "homepage": "https://github.com/phpspec/prophecy",
+      "keywords": [
+        "Double",
+        "Dummy",
+        "fake",
+        "mock",
+        "spy",
+        "stub"
+      ],
+      "time": "2020-01-20T15:57:02+00:00"
+    },
+    {
+      "name": "phpunit/php-code-coverage",
+      "version": "5.3.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+        "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+        "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
+        "shasum": ""
+      },
+      "require": {
+        "ext-dom": "*",
+        "ext-xmlwriter": "*",
+        "php": "^7.0",
+        "phpunit/php-file-iterator": "^1.4.2",
+        "phpunit/php-text-template": "^1.2.1",
+        "phpunit/php-token-stream": "^2.0.1",
+        "sebastian/code-unit-reverse-lookup": "^1.0.1",
+        "sebastian/environment": "^3.0",
+        "sebastian/version": "^2.0.1",
+        "theseer/tokenizer": "^1.1"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^6.0"
+      },
+      "suggest": {
+        "ext-xdebug": "^2.5.5"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "5.3.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de",
+          "role": "lead"
+        }
+      ],
+      "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+      "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+      "keywords": [
+        "coverage",
+        "testing",
+        "xunit"
+      ],
+      "time": "2018-04-06T15:36:58+00:00"
+    },
+    {
+      "name": "phpunit/php-file-iterator",
+      "version": "1.4.5",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+        "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+        "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.3.3"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.4.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sb@sebastian-bergmann.de",
+          "role": "lead"
+        }
+      ],
+      "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+      "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+      "keywords": [
+        "filesystem",
+        "iterator"
+      ],
+      "time": "2017-11-27T13:52:08+00:00"
+    },
+    {
+      "name": "phpunit/php-text-template",
+      "version": "1.2.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/php-text-template.git",
+        "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+        "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.3.3"
+      },
+      "type": "library",
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de",
+          "role": "lead"
+        }
+      ],
+      "description": "Simple template engine.",
+      "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+      "keywords": [
+        "template"
+      ],
+      "time": "2015-06-21T13:50:34+00:00"
+    },
+    {
+      "name": "phpunit/php-timer",
+      "version": "1.0.9",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/php-timer.git",
+        "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+        "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^5.3.3 || ^7.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.0-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sb@sebastian-bergmann.de",
+          "role": "lead"
+        }
+      ],
+      "description": "Utility class for timing",
+      "homepage": "https://github.com/sebastianbergmann/php-timer/",
+      "keywords": [
+        "timer"
+      ],
+      "time": "2017-02-26T11:10:40+00:00"
+    },
+    {
+      "name": "phpunit/php-token-stream",
+      "version": "2.0.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+        "reference": "791198a2c6254db10131eecfe8c06670700904db"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+        "reference": "791198a2c6254db10131eecfe8c06670700904db",
+        "shasum": ""
+      },
+      "require": {
+        "ext-tokenizer": "*",
+        "php": "^7.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^6.2.4"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.0-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de"
+        }
+      ],
+      "description": "Wrapper around PHP's tokenizer extension.",
+      "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+      "keywords": [
+        "tokenizer"
+      ],
+      "time": "2017-11-27T05:48:46+00:00"
+    },
+    {
+      "name": "phpunit/phpunit",
+      "version": "6.5.14",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/phpunit.git",
+        "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+        "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+        "shasum": ""
+      },
+      "require": {
+        "ext-dom": "*",
+        "ext-json": "*",
+        "ext-libxml": "*",
+        "ext-mbstring": "*",
+        "ext-xml": "*",
+        "myclabs/deep-copy": "^1.6.1",
+        "phar-io/manifest": "^1.0.1",
+        "phar-io/version": "^1.0",
+        "php": "^7.0",
+        "phpspec/prophecy": "^1.7",
+        "phpunit/php-code-coverage": "^5.3",
+        "phpunit/php-file-iterator": "^1.4.3",
+        "phpunit/php-text-template": "^1.2.1",
+        "phpunit/php-timer": "^1.0.9",
+        "phpunit/phpunit-mock-objects": "^5.0.9",
+        "sebastian/comparator": "^2.1",
+        "sebastian/diff": "^2.0",
+        "sebastian/environment": "^3.1",
+        "sebastian/exporter": "^3.1",
+        "sebastian/global-state": "^2.0",
+        "sebastian/object-enumerator": "^3.0.3",
+        "sebastian/resource-operations": "^1.0",
+        "sebastian/version": "^2.0.1"
+      },
+      "conflict": {
+        "phpdocumentor/reflection-docblock": "3.0.2",
+        "phpunit/dbunit": "<3.0"
+      },
+      "require-dev": {
+        "ext-pdo": "*"
+      },
+      "suggest": {
+        "ext-xdebug": "*",
+        "phpunit/php-invoker": "^1.1"
+      },
+      "bin": [
+        "phpunit"
+      ],
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "6.5.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de",
+          "role": "lead"
+        }
+      ],
+      "description": "The PHP Unit Testing framework.",
+      "homepage": "https://phpunit.de/",
+      "keywords": [
+        "phpunit",
+        "testing",
+        "xunit"
+      ],
+      "time": "2019-02-01T05:22:47+00:00"
+    },
+    {
+      "name": "phpunit/phpunit-mock-objects",
+      "version": "5.0.10",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+        "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
+        "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
+        "shasum": ""
+      },
+      "require": {
+        "doctrine/instantiator": "^1.0.5",
+        "php": "^7.0",
+        "phpunit/php-text-template": "^1.2.1",
+        "sebastian/exporter": "^3.1"
+      },
+      "conflict": {
+        "phpunit/phpunit": "<6.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^6.5.11"
+      },
+      "suggest": {
+        "ext-soap": "*"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "5.0.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de",
+          "role": "lead"
+        }
+      ],
+      "description": "Mock Object library for PHPUnit",
+      "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+      "keywords": [
+        "mock",
+        "xunit"
+      ],
+      "abandoned": true,
+      "time": "2018-08-09T05:50:03+00:00"
+    },
+    {
+      "name": "sebastian/code-unit-reverse-lookup",
+      "version": "1.0.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+        "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+        "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^5.6 || ^7.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^5.7 || ^6.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.0.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de"
+        }
+      ],
+      "description": "Looks up which function or method a line of code belongs to",
+      "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+      "time": "2017-03-04T06:30:41+00:00"
+    },
+    {
+      "name": "sebastian/comparator",
+      "version": "2.1.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/comparator.git",
+        "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+        "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.0",
+        "sebastian/diff": "^2.0 || ^3.0",
+        "sebastian/exporter": "^3.1"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^6.4"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.1.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Jeff Welch",
+          "email": "whatthejeff@gmail.com"
+        },
+        {
+          "name": "Volker Dusch",
+          "email": "github@wallbash.com"
+        },
+        {
+          "name": "Bernhard Schussek",
+          "email": "bschussek@2bepublished.at"
+        },
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de"
+        }
+      ],
+      "description": "Provides the functionality to compare PHP values for equality",
+      "homepage": "https://github.com/sebastianbergmann/comparator",
+      "keywords": [
+        "comparator",
+        "compare",
+        "equality"
+      ],
+      "time": "2018-02-01T13:46:46+00:00"
+    },
+    {
+      "name": "sebastian/diff",
+      "version": "2.0.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/diff.git",
+        "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+        "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^6.2"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.0-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Kore Nordmann",
+          "email": "mail@kore-nordmann.de"
+        },
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de"
+        }
+      ],
+      "description": "Diff implementation",
+      "homepage": "https://github.com/sebastianbergmann/diff",
+      "keywords": [
+        "diff"
+      ],
+      "time": "2017-08-03T08:09:46+00:00"
+    },
+    {
+      "name": "sebastian/environment",
+      "version": "3.1.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/environment.git",
+        "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+        "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^6.1"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "3.1.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de"
+        }
+      ],
+      "description": "Provides functionality to handle HHVM/PHP environments",
+      "homepage": "http://www.github.com/sebastianbergmann/environment",
+      "keywords": [
+        "Xdebug",
+        "environment",
+        "hhvm"
+      ],
+      "time": "2017-07-01T08:51:00+00:00"
+    },
+    {
+      "name": "sebastian/exporter",
+      "version": "3.1.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/exporter.git",
+        "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+        "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.0",
+        "sebastian/recursion-context": "^3.0"
+      },
+      "require-dev": {
+        "ext-mbstring": "*",
+        "phpunit/phpunit": "^6.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "3.1.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de"
+        },
+        {
+          "name": "Jeff Welch",
+          "email": "whatthejeff@gmail.com"
+        },
+        {
+          "name": "Volker Dusch",
+          "email": "github@wallbash.com"
+        },
+        {
+          "name": "Adam Harvey",
+          "email": "aharvey@php.net"
+        },
+        {
+          "name": "Bernhard Schussek",
+          "email": "bschussek@gmail.com"
+        }
+      ],
+      "description": "Provides the functionality to export PHP variables for visualization",
+      "homepage": "http://www.github.com/sebastianbergmann/exporter",
+      "keywords": [
+        "export",
+        "exporter"
+      ],
+      "time": "2019-09-14T09:02:43+00:00"
+    },
+    {
+      "name": "sebastian/global-state",
+      "version": "2.0.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/global-state.git",
+        "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+        "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^6.0"
+      },
+      "suggest": {
+        "ext-uopz": "*"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.0-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de"
+        }
+      ],
+      "description": "Snapshotting of global state",
+      "homepage": "http://www.github.com/sebastianbergmann/global-state",
+      "keywords": [
+        "global state"
+      ],
+      "time": "2017-04-27T15:39:26+00:00"
+    },
+    {
+      "name": "sebastian/object-enumerator",
+      "version": "3.0.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+        "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+        "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.0",
+        "sebastian/object-reflector": "^1.1.1",
+        "sebastian/recursion-context": "^3.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^6.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "3.0.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de"
+        }
+      ],
+      "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+      "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+      "time": "2017-08-03T12:35:26+00:00"
+    },
+    {
+      "name": "sebastian/object-reflector",
+      "version": "1.1.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/object-reflector.git",
+        "reference": "773f97c67f28de00d397be301821b06708fca0be"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+        "reference": "773f97c67f28de00d397be301821b06708fca0be",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^6.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.1-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de"
+        }
+      ],
+      "description": "Allows reflection of object attributes, including inherited and non-public ones",
+      "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+      "time": "2017-03-29T09:07:27+00:00"
+    },
+    {
+      "name": "sebastian/recursion-context",
+      "version": "3.0.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/recursion-context.git",
+        "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+        "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^7.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^6.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "3.0.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Jeff Welch",
+          "email": "whatthejeff@gmail.com"
+        },
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de"
+        },
+        {
+          "name": "Adam Harvey",
+          "email": "aharvey@php.net"
+        }
+      ],
+      "description": "Provides functionality to recursively process PHP variables",
+      "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+      "time": "2017-03-03T06:23:57+00:00"
+    },
+    {
+      "name": "sebastian/resource-operations",
+      "version": "1.0.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/resource-operations.git",
+        "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+        "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.6.0"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.0.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de"
+        }
+      ],
+      "description": "Provides a list of PHP built-in functions that operate on resources",
+      "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+      "time": "2015-07-28T20:34:47+00:00"
+    },
+    {
+      "name": "sebastian/version",
+      "version": "2.0.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/sebastianbergmann/version.git",
+        "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+        "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.6"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.0.x-dev"
+        }
+      },
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Sebastian Bergmann",
+          "email": "sebastian@phpunit.de",
+          "role": "lead"
+        }
+      ],
+      "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+      "homepage": "https://github.com/sebastianbergmann/version",
+      "time": "2016-10-03T07:35:21+00:00"
+    },
+    {
+      "name": "symfony/polyfill-ctype",
+      "version": "v1.13.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/symfony/polyfill-ctype.git",
+        "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+        "reference": "f8f0b461be3385e56d6de3dbb5a0df24c0c275e3",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=5.3.3"
+      },
+      "suggest": {
+        "ext-ctype": "For best performance"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.13-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Symfony\\Polyfill\\Ctype\\": ""
+        },
+        "files": [
+          "bootstrap.php"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Gert de Pagter",
+          "email": "BackEndTea@gmail.com"
+        },
+        {
+          "name": "Symfony Community",
+          "homepage": "https://symfony.com/contributors"
+        }
+      ],
+      "description": "Symfony polyfill for ctype functions",
+      "homepage": "https://symfony.com",
+      "keywords": [
+        "compatibility",
+        "ctype",
+        "polyfill",
+        "portable"
+      ],
+      "time": "2019-11-27T13:56:44+00:00"
+    },
+    {
+      "name": "theseer/tokenizer",
+      "version": "1.1.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/theseer/tokenizer.git",
+        "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+        "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+        "shasum": ""
+      },
+      "require": {
+        "ext-dom": "*",
+        "ext-tokenizer": "*",
+        "ext-xmlwriter": "*",
+        "php": "^7.0"
+      },
+      "type": "library",
+      "autoload": {
+        "classmap": [
+          "src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Arne Blankerts",
+          "email": "arne@blankerts.de",
+          "role": "Developer"
+        }
+      ],
+      "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+      "time": "2019-06-13T22:48:21+00:00"
+    },
+    {
+      "name": "webmozart/assert",
+      "version": "1.6.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/webmozart/assert.git",
+        "reference": "573381c0a64f155a0d9a23f4b0c797194805b925"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/webmozart/assert/zipball/573381c0a64f155a0d9a23f4b0c797194805b925",
+        "reference": "573381c0a64f155a0d9a23f4b0c797194805b925",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^5.3.3 || ^7.0",
+        "symfony/polyfill-ctype": "^1.8"
+      },
+      "conflict": {
+        "vimeo/psalm": "<3.6.0"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Webmozart\\Assert\\": "src/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Bernhard Schussek",
+          "email": "bschussek@gmail.com"
+        }
+      ],
+      "description": "Assertions to validate method input/output with nice error messages.",
+      "keywords": [
+        "assert",
+        "check",
+        "validate"
+      ],
+      "time": "2019-11-24T13:36:37+00:00"
+    }
+  ],
+  "aliases": [],
+  "minimum-stability": "stable",
+  "stability-flags": [],
+  "prefer-stable": false,
+  "prefer-lowest": false,
+  "platform": {
+    "php": ">=7",
+    "ext-json": "*"
+  },
+  "platform-dev": []
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,11 @@
 <phpunit
-    beStrictAboutOutputDuringTests="true"
-    beStrictAboutTestSize="false"
-    beStrictAboutTestsThatDoNotTestAnything="true"
-    bootstrap="vendor/autoload.php"
-    mapTestClassNameToCoveredClassName="false"
-    colors="true"
-    verbose="true"
+        beStrictAboutOutputDuringTests="true"
+        beStrictAboutTestSize="false"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        bootstrap="vendor/autoload.php"
+        mapTestClassNameToCoveredClassName="false"
+        colors="true"
+        verbose="true"
 >
     <testsuites>
         <testsuite name="GetterSetter">
@@ -14,7 +14,7 @@
     </testsuites>
 
     <logging>
-        <log type="coverage-text" target="php://stdout" lowUpperBound="35" highLowerBound="90" />
+        <log type="coverage-text" target="php://stdout" lowUpperBound="35" highLowerBound="90"/>
     </logging>
 
     <filter>

--- a/src/GetSet.php
+++ b/src/GetSet.php
@@ -9,11 +9,12 @@
 namespace Revinate\GetterSetter;
 
 
-class GetSet implements GetSetInterface {
+class GetSet implements GetSetInterface
+{
     /**
      * @description Gets the value for the field $fieldName.
      * @param string $fieldName
-     * @param null   $default
+     * @param null $default
      * @return mixed
      */
     public function getValue($fieldName, $default = null) {
@@ -27,7 +28,7 @@ class GetSet implements GetSetInterface {
     /**
      * @description Sets the value for the field $fieldName
      * @param string $fieldName
-     * @param mixed  $value
+     * @param mixed $value
      * @return $this
      */
     public function setValue($fieldName, $value) {

--- a/src/GetSetInterface.php
+++ b/src/GetSetInterface.php
@@ -9,12 +9,13 @@
 namespace Revinate\GetterSetter;
 
 
-interface GetSetInterface {
+interface GetSetInterface
+{
 
     /**
      * @description Gets the value for the field $fieldName.
      * @param string $fieldName
-     * @param null   $default
+     * @param null $default
      * @return mixed
      */
     public function getValue($fieldName, $default = null);

--- a/src/GetSetPath.php
+++ b/src/GetSetPath.php
@@ -8,13 +8,15 @@
 
 namespace Revinate\GetterSetter;
 
-class GetSetPath extends GetSet implements GetSetPathInterface {
+class GetSetPath extends GetSet implements GetSetPathInterface
+{
 
     /**
      * @param string|string[] $pathToField
-     * @param mixed|null      $default
-     * @param string          $pathSeparator
+     * @param mixed|null $default
+     * @param string $pathSeparator
      * @return mixed
+     * @throws UnableToGetFieldException
      */
     public function getPathValue($pathToField, $default = null, $pathSeparator = '.') {
         return get($this, $pathToField, $default, $pathSeparator);
@@ -22,9 +24,10 @@ class GetSetPath extends GetSet implements GetSetPathInterface {
 
     /**
      * @param string|string[] $pathToField
-     * @param mixed           $value
-     * @param string          $pathSeparator
+     * @param mixed $value
+     * @param string $pathSeparator
      * @return mixed
+     * @throws UnableToSetFieldException
      */
     public function setPathValue($pathToField, $value, $pathSeparator = '.') {
         return set($this, $pathToField, $value, $pathSeparator);
@@ -32,9 +35,10 @@ class GetSetPath extends GetSet implements GetSetPathInterface {
 
     /**
      * @description Gets the field value based upon the path.
-     * @param array      $pathToField
+     * @param array $pathToField
      * @param null|mixed $default
      * @return mixed
+     * @throws UnableToGetFieldException
      */
     public function getByArrayPath($pathToField, $default = null) {
         return getValueByArrayPath($this, $pathToField, $default);
@@ -45,6 +49,7 @@ class GetSetPath extends GetSet implements GetSetPathInterface {
      * @param array $pathToField
      * @param mixed $value
      * @return $this
+     * @throws UnableToSetFieldException
      */
     public function setByArrayPath($pathToField, $value) {
         return setValueByArrayPath($this, $pathToField, $value);

--- a/src/GetSetPathInterface.php
+++ b/src/GetSetPathInterface.php
@@ -9,12 +9,13 @@
 namespace Revinate\GetterSetter;
 
 
-interface GetSetPathInterface extends GetSetInterface {
+interface GetSetPathInterface extends GetSetInterface
+{
 
     /**
      * @description Gets the field value based upon the path.
      * @param array $pathToField
-     * @param null|mixed   $default
+     * @param null|mixed $default
      * @return mixed
      */
     public function getByArrayPath($pathToField, $default = null);
@@ -22,7 +23,7 @@ interface GetSetPathInterface extends GetSetInterface {
     /**
      * @description Sets the field value based upon the path.
      * @param array $pathToField
-     * @param mixed   $value
+     * @param mixed $value
      * @return $this
      */
     public function setByArrayPath($pathToField, $value);

--- a/src/GetterSetter.php
+++ b/src/GetterSetter.php
@@ -10,16 +10,18 @@ namespace Revinate\GetterSetter;
 
 use Revinate\GetterSetter as gs;
 
-class GetterSetter implements GetterSetterInterface {
+class GetterSetter implements GetterSetterInterface
+{
 
     protected $pathSeparator = '.';
 
     /**
      * @description Gets the value for the field $fieldName.
      * @param array|object $data
-     * @param string       $fieldName
-     * @param null         $default
+     * @param string $fieldName
+     * @param null $default
      * @return mixed
+     * @throws UnableToGetFieldException
      */
     public function getValue($data, $fieldName, $default = null) {
         return gs\getValue($data, $fieldName, $default);
@@ -28,9 +30,10 @@ class GetterSetter implements GetterSetterInterface {
     /**
      * @description Sets the value for the field $fieldName
      * @param array|object $data
-     * @param string       $fieldName
-     * @param mixed        $value
+     * @param string $fieldName
+     * @param mixed $value
      * @return $this
+     * @throws UnableToSetFieldException
      */
     public function setValue($data, $fieldName, $value) {
         return gs\setValue($data, $fieldName, $value);
@@ -39,9 +42,10 @@ class GetterSetter implements GetterSetterInterface {
     /**
      * @description Gets the field value based upon the path.
      * @param array|object $data
-     * @param array        $pathToField
-     * @param null|mixed   $default
+     * @param array $pathToField
+     * @param null|mixed $default
      * @return mixed
+     * @throws UnableToGetFieldException
      */
     public function getValueByArrayPath($data, $pathToField, $default = null) {
         return gs\getValueByArrayPath($data, $pathToField, $default);
@@ -50,9 +54,10 @@ class GetterSetter implements GetterSetterInterface {
     /**
      * @description Sets the field value based upon the path.
      * @param array|object $data
-     * @param array        $pathToField
-     * @param mixed        $value
+     * @param array $pathToField
+     * @param mixed $value
      * @return mixed
+     * @throws UnableToSetFieldException
      */
     public function setValueByArrayPath($data, $pathToField, $value) {
         return gs\setValueByArrayPath($data, $pathToField, $value);
@@ -62,9 +67,10 @@ class GetterSetter implements GetterSetterInterface {
      * @description Gets the field value based upon the path.
      * @param array|object $data
      * @param string|array $pathToField
-     * @param null|mixed   $default
-     * @param string|null  $pathSeparator Optional path separator.
+     * @param null|mixed $default
+     * @param string|null $pathSeparator Optional path separator.
      * @return mixed
+     * @throws UnableToGetFieldException
      */
     public function get($data, $pathToField, $default = null, $pathSeparator = null) {
         $pathSeparator = $pathSeparator ?: $this->pathSeparator;
@@ -75,9 +81,10 @@ class GetterSetter implements GetterSetterInterface {
      * @description Sets the field value based upon the path.
      * @param array|object $data
      * @param string|array $pathToField
-     * @param mixed        $value
-     * @param string       $pathSeparator
+     * @param mixed $value
+     * @param string $pathSeparator
      * @return mixed
+     * @throws UnableToSetFieldException
      */
     public function set($data, $pathToField, $value, $pathSeparator = null) {
         $pathSeparator = $pathSeparator ?: $this->pathSeparator;

--- a/src/GetterSetterInterface.php
+++ b/src/GetterSetterInterface.php
@@ -9,12 +9,13 @@
 namespace Revinate\GetterSetter;
 
 
-interface GetterSetterInterface {
+interface GetterSetterInterface
+{
     /**
      * @description Gets the value for the field $fieldName.
      * @param array|object $data
-     * @param string       $fieldName
-     * @param null         $default
+     * @param string $fieldName
+     * @param null $default
      * @return mixed
      */
     public function getValue($data, $fieldName, $default = null);
@@ -22,8 +23,8 @@ interface GetterSetterInterface {
     /**
      * @description Sets the value for the field $fieldName
      * @param array|object $data
-     * @param string       $fieldName
-     * @param mixed        $value
+     * @param string $fieldName
+     * @param mixed $value
      * @return mixed - the updated $data array or object.
      */
     public function setValue($data, $fieldName, $value);
@@ -31,8 +32,8 @@ interface GetterSetterInterface {
     /**
      * @description Gets the field value based upon the path.
      * @param array|object $data
-     * @param array        $pathToField
-     * @param null|mixed   $default
+     * @param array $pathToField
+     * @param null|mixed $default
      * @return mixed
      */
     public function getValueByArrayPath($data, $pathToField, $default = null);
@@ -40,8 +41,8 @@ interface GetterSetterInterface {
     /**
      * @description Sets the field value based upon the path.
      * @param array|object $data
-     * @param array        $pathToField
-     * @param mixed        $value
+     * @param array $pathToField
+     * @param mixed $value
      */
     public function setValueByArrayPath($data, $pathToField, $value);
 
@@ -49,7 +50,7 @@ interface GetterSetterInterface {
      * @description Gets the field value based upon the path.
      * @param array|object $data
      * @param string|array $pathToField
-     * @param null|mixed   $default
+     * @param null|mixed $default
      * @param string $pathSeparator
      * @return mixed - the updated $data array or object.
      */
@@ -59,7 +60,7 @@ interface GetterSetterInterface {
      * @description Sets the field value based upon the path.
      * @param array|object $data
      * @param string|array $pathToField
-     * @param mixed   $value
+     * @param mixed $value
      * @param string $pathSeparator
      * @return mixed - the updated $data array or object.
      */

--- a/src/UnableToGetFieldException.php
+++ b/src/UnableToGetFieldException.php
@@ -9,5 +9,8 @@
 namespace Revinate\GetterSetter;
 
 
-class UnableToGetFieldException extends \Exception {
+use Exception;
+
+class UnableToGetFieldException extends Exception
+{
 }

--- a/src/UnableToSetFieldException.php
+++ b/src/UnableToSetFieldException.php
@@ -9,5 +9,8 @@
 namespace Revinate\GetterSetter;
 
 
-class UnableToSetFieldException extends \Exception {
+use Exception;
+
+class UnableToSetFieldException extends Exception
+{
 }

--- a/src/setValueFunctions.php
+++ b/src/setValueFunctions.php
@@ -9,16 +9,19 @@
 namespace Revinate\GetterSetter;
 
 
+use ArrayAccess;
+use Closure;
+
 /**
- * @param array|object    $doc
+ * @param array|object $doc
  * @param string|string[] $fieldPath
- * @param mixed           $value
- * @param string          $pathSeparator
+ * @param mixed $value
+ * @param string $pathSeparator
  * @return mixed the updated document
  * @throws UnableToSetFieldException
  */
 function set($doc, $fieldPath, $value, $pathSeparator = '.') {
-    $path = is_array($fieldPath) || ($fieldPath instanceof \ArrayAccess)
+    $path = is_array($fieldPath) || ($fieldPath instanceof ArrayAccess)
         ? $fieldPath
         : explode($pathSeparator, $fieldPath);
     return setValueByArrayPath($doc, $path, $value);
@@ -26,24 +29,24 @@ function set($doc, $fieldPath, $value, $pathSeparator = '.') {
 
 /**
  * @param array|object $doc
- * @param string       $fieldName
- * @param mixed        $value
- * @return array|\ArrayAccess
+ * @param string $fieldName
+ * @param mixed $value
+ * @return array|ArrayAccess
  * @throws UnableToSetFieldException
  */
 function setValue($doc, $fieldName, $value) {
     if ($doc instanceof GetSetInterface) {
         return $doc->setValue($fieldName, $value);
     }
-    if (is_null($doc)) {
-        $doc = array();
+    if ($doc === null) {
+        $doc = [];
     }
-    if (is_array($doc) || $doc instanceof \ArrayAccess) {
+    if (is_array($doc) || $doc instanceof ArrayAccess) {
         $doc[$fieldName] = $value;
         return $doc;
     }
 
-    if (is_object($doc) && ! $doc instanceof \Closure) {
+    if (is_object($doc) && !$doc instanceof Closure) {
         // Does the property exist?
         $fields = get_object_vars($doc);
         if (array_key_exists($fieldName, $fields)) {
@@ -59,9 +62,10 @@ function setValue($doc, $fieldName, $value) {
 
         // Try using setters
         $fieldNameCamel = util\toCamelCase($fieldName);
-        $setters = array(
-            'set'.$fieldNameCamel, $fieldName,
-        );
+        $setters = [
+            'set' . $fieldNameCamel,
+            $fieldName,
+        ];
         foreach ($setters as $methodName) {
             if (method_exists($doc, $methodName)) {
                 $doc->{$methodName}($value);
@@ -80,8 +84,8 @@ function setValue($doc, $fieldName, $value) {
 
 /**
  * @param array|object $doc
- * @param string[]     $fieldPath
- * @param mixed        $value
+ * @param string[] $fieldPath
+ * @param mixed $value
  * @return mixed the updated document
  * @throws UnableToSetFieldException
  */
@@ -91,9 +95,9 @@ function setValueByArrayPath($doc, $fieldPath, $value) {
         return $value;
     }
     // Special case for nulls, treat them like empty arrays.
-    $doc = is_null($doc) ? array() : $doc;
+    $doc = $doc === null ? [] : $doc;
     $fieldName = array_shift($fieldPath);
-    $subDoc = getValue($doc, $fieldName, array());
+    $subDoc = getValue($doc, $fieldName, []);
     $subDocUpdated = setValueByArrayPath($subDoc, $fieldPath, $value);
     if ($subDocUpdated !== $subDoc) {
         $doc = setValue($doc, $fieldName, $subDocUpdated);

--- a/src/util/utils.php
+++ b/src/util/utils.php
@@ -13,7 +13,6 @@ namespace Revinate\GetterSetter\util;
  * @param string $string
  * @return string
  */
-function toCamelCase($string)
-{
-    return strtr(ucwords(strtr($string, array('_' => ' '))), array(' ' => ''));
+function toCamelCase($string) {
+    return strtr(ucwords(strtr($string, ['_' => ' '])), [' ' => '']);
 }

--- a/test/AccessTestClass.php
+++ b/test/AccessTestClass.php
@@ -13,27 +13,28 @@ namespace Revinate\GetterSetter\test;
  * @package Revinate\GetterSetter\test
  * @codeCoverageIgnore
  */
-class AccessTestClass {
+class AccessTestClass
+{
 
-    public    $isPublic    = true;
+    public $isPublic = true;
     protected $isProtected = true;
-    private   $isPrivate   = true;
+    private $isPrivate = true;
 
-    public    $isNotPrivate = true;
-    protected $isNotPublic  = true;
+    public $isNotPrivate = true;
+    protected $isNotPublic = true;
 
-    public    $public    = 'public';
+    public $public = 'public';
     protected $protected = 'protected';
-    private   $private   = 'private';
+    private $private = 'private';
 
-    public    $nullValue          = null;
+    public $nullValue = null;
     protected $nullValueProtected = null;
 
-    private   $methodGetterSetterValue = 'method';
+    private $methodGetterSetterValue = 'method';
 
-    public    $public_string_value    = 'public_string_value';
+    public $public_string_value = 'public_string_value';
     protected $protected_string_value = 'protected_string_value';
-    private   $private_string_value   = 'private_string_value';
+    private $private_string_value = 'private_string_value';
 
     /**
      * @return boolean
@@ -180,7 +181,7 @@ class AccessTestClass {
      */
     public function methodGetterSetter() {
         $args = func_get_args();
-        if (! empty($args)) {
+        if (!empty($args)) {
             $this->methodGetterSetterValue = $args[0];
         }
         return $this->methodGetterSetterValue;

--- a/test/ArrayObjectTest.php
+++ b/test/ArrayObjectTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php /** @noinspection PhpUnhandledExceptionInspection */
+
 /**
  * Created by PhpStorm.
  * User: jasondent
@@ -8,37 +9,38 @@
 
 namespace Revinate\GetterSetter\test;
 
+use PHPUnit\Framework\TestCase;
 use Revinate\GetterSetter as gs;
 
-class ArrayObjectTest extends \PHPUnit_Framework_TestCase {
+class ArrayObjectTest extends TestCase
+{
 
     /**
      * @return object
      */
     protected function getData() {
-        return (object) array(
-            'a' => array(
+        return (object)[
+            'a' => [
                 'aa' => 'aa',
                 'ab' => 'ab',
-            ),
-            'b' => array(
-                'ba' => (object) array(
+            ],
+            'b' => [
+                'ba' => (object)[
                     'baa' => 'baa',
                     'bab' => 'bab',
-                ),
-            ),
+                ],
+            ],
             'c' => null
-        );
+        ];
     }
 
     public function test() {
         $data = new \ArrayObject($this->getData());
 
         $this->assertEquals('aa', gs\get($data, 'a.aa'));
-        $this->assertEquals(null, gs\get($data, 'c', 'default'));
         $this->assertEquals('default', gs\get($data, 'd', 'default'));
 
-        gs\set($data, 'd', array(0,1,2,3,4,5));
+        gs\set($data, 'd', [0, 1, 2, 3, 4, 5]);
         $this->assertEquals(4, gs\get($data, 'd.4'));
     }
 

--- a/test/GetFunctionsTest.php
+++ b/test/GetFunctionsTest.php
@@ -1,4 +1,6 @@
 <?php
+/** @noinspection PhpUnhandledExceptionInspection */
+
 /**
  * Created by PhpStorm.
  * User: jasondent
@@ -8,51 +10,54 @@
 
 namespace Revinate\GetterSetter\test;
 
+use PHPUnit\Framework\TestCase;
 use Revinate\GetterSetter as gs;
+use Revinate\GetterSetter\GetSet;
 
-class GetFunctionsTest extends \PHPUnit_Framework_TestCase {
+class GetFunctionsTest extends TestCase
+{
 
     /**
      * @return array
      * @codeCoverageIgnore
      */
     public function providerGetters() {
-        $default = (object) array('hidden', 'value'=>'default');
-        return array(
-            array('isPublic',           $default, true),
-            array('isProtected',        $default, true),
-            array('isPrivate',          $default, true),
-            array('isNotPrivate',       $default, true),
-            array('isNotPublic',        $default, true),
-            array('public',             $default, 'public'),
-            array('protected',          $default, 'protected'),
-            array('private',            $default, 'private'),
-            array('nullValue',          $default, null),
-            array('nullValueProtected', $default, null),
-            array('methodGetterSetter', $default, 'method'),
+        $default = (object)['hidden', 'value' => 'default'];
+        return [
+            ['isPublic', $default, true],
+            ['isProtected', $default, true],
+            ['isPrivate', $default, true],
+            ['isNotPrivate', $default, true],
+            ['isNotPublic', $default, true],
+            ['public', $default, 'public'],
+            ['protected', $default, 'protected'],
+            ['private', $default, 'private'],
+            ['nullValue', $default, null],
+            ['nullValueProtected', $default, null],
+            ['methodGetterSetter', $default, 'method'],
 
             // non-existing but should return a value.
-            array('notPrivate',         $default, true),
-            array('notPublic',          $default, true),
+            ['notPrivate', $default, true],
+            ['notPublic', $default, true],
 
             // test underscore
-            array('is_public',              $default, true),
-            array('is_protected',           $default, true),
-            array('is_private',             $default, true),
-            array('is_not_private',         $default, true),
-            array('is_not_public',          $default, true),
-            array('null_value',             $default, null),
-            array('null_value_protected',   $default, null),
-            array('method_getter_setter',   $default, 'method'),
-            array('public_string_value',    $default, 'public_string_value'),
-            array('protected_string_value', $default, 'protected_string_value'),
-            array('private_string_value',   $default, 'private_string_value'),
+            ['is_public', $default, true],
+            ['is_protected', $default, true],
+            ['is_private', $default, true],
+            ['is_not_private', $default, true],
+            ['is_not_public', $default, true],
+            ['null_value', $default, null],
+            ['null_value_protected', $default, null],
+            ['method_getter_setter', $default, 'method'],
+            ['public_string_value', $default, 'public_string_value'],
+            ['protected_string_value', $default, 'protected_string_value'],
+            ['private_string_value', $default, 'private_string_value'],
 
             // non-existing, should return default
-            array('notFound',                   $default, $default),
-            array('methodGetterSetterValue',    $default, $default),
+            ['notFound', $default, $default],
+            ['methodGetterSetterValue', $default, $default],
 
-        );
+        ];
     }
 
     /**
@@ -60,7 +65,6 @@ class GetFunctionsTest extends \PHPUnit_Framework_TestCase {
      * @param $default
      * @param $expectedValue
      * @dataProvider providerGetters
-     *
      */
     public function testGetValue($fieldName, $default, $expectedValue) {
         $testClass = new AccessTestClass();
@@ -71,9 +75,9 @@ class GetFunctionsTest extends \PHPUnit_Framework_TestCase {
 
 
         gs\setValue($getSetClass, 'a', new gs\GetSet());
-        $this->assertInstanceOf('Revinate\GetterSetter\GetSet', gs\getValue($getSetClass, 'a'));
+        $this->assertInstanceOf(GetSet::class, gs\getValue($getSetClass, 'a'));
 
-        $notFound = (object)array();
+        $notFound = (object)[];
 
         $this->assertEquals($notFound, gs\getValue($getSetClass, 'b', $notFound));
 
@@ -84,28 +88,28 @@ class GetFunctionsTest extends \PHPUnit_Framework_TestCase {
     public function testGetMagic() {
         $testClass = new MagicAccessGetTestClass();
 
-        $notFound = (object) array();
-        
+        $notFound = (object)[];
+
         $this->assertNotEquals($notFound, gs\getValue($testClass, 'a', $notFound));
         $this->assertNull(gs\getValue($testClass, 'a', $notFound));
     }
 
     public function testNull() {
-        $notFound = (object) array();
+        $notFound = (object)[];
         $this->assertEquals($notFound, gs\getValue(null, 'name', $notFound));
     }
 
     public function testNullFields() {
-        $doc = array(
+        $doc = [
             'location' => null,
-            'info' => array(
+            'info' => [
                 'companyName' => null,
                 'address' => null,
                 'extra' => null,
-            ),
-        );
+            ],
+        ];
 
-        $notFound = (object) array();
+        $notFound = (object)[];
         $this->assertEquals($notFound, gs\get($doc, 'location.lat', $notFound));
         $this->assertNull(gs\get($doc, 'location', $notFound));
     }

--- a/test/GetSetPathTest.php
+++ b/test/GetSetPathTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php /** @noinspection PhpUnhandledExceptionInspection */
+
 /**
  * Created by PhpStorm.
  * User: jasondent
@@ -8,23 +9,18 @@
 
 namespace Revinate\GetterSetter\test;
 
+use PHPUnit\Framework\TestCase;
 use Revinate\GetterSetter as gs;
 
-class TestGetSetPath extends \PHPUnit_Framework_TestCase {
+class GetSetPathTest extends TestCase
+{
 
     public function testSetEmptyPath() {
-        $uniqueObject = (object) array();
+        $uniqueObject = (object)[];
 
-        $this->assertEquals($uniqueObject, gs\set(array(), array(), $uniqueObject));
+        $this->assertEquals($uniqueObject, gs\set([], [], $uniqueObject));
     }
 
-
-    /**
-     * @covers Revinate\GetterSetter\GetSetPath::setPathValue
-     * @covers Revinate\GetterSetter\GetSetPath::getPathValue
-     * @covers Revinate\GetterSetter\GetSetPath::getByArrayPath
-     * @covers Revinate\GetterSetter\GetSetPath::setByArrayPath
-     */
     public function testGetSetPathClass() {
         $gsp = new gs\GetSetPath();
 

--- a/test/GetSetTest.php
+++ b/test/GetSetTest.php
@@ -9,13 +9,15 @@
 namespace Revinate\GetterSetter\test;
 
 
+use PHPUnit\Framework\TestCase;
 use Revinate\GetterSetter\GetSet;
 
-class GetSetTest extends \PHPUnit_Framework_TestCase {
+class GetSetTest extends TestCase
+{
 
     public function testGetSet() {
         $gs = new GetSet();
-        $notFound = (object)array();
+        $notFound = (object)[];
 
         $this->assertEquals($notFound, $gs->getValue('a', $notFound));
 

--- a/test/GetterSetterTest.php
+++ b/test/GetterSetterTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php /** @noinspection PhpUnhandledExceptionInspection */
+
 /**
  * Created by PhpStorm.
  * User: jasondent
@@ -9,43 +10,45 @@
 namespace Revinate\GetterSetter\test;
 
 
+use PHPUnit\Framework\TestCase;
 use Revinate\GetterSetter\GetterSetter;
 
-class GetterSetterTest extends \PHPUnit_Framework_TestCase {
+class GetterSetterTest extends TestCase
+{
 
     /**
      * @return object
      * @codeCoverageIgnore
      */
     protected function getData() {
-        return (object) array(
-            'a' => array(
+        return (object)[
+            'a' => [
                 'aa' => 'aa',
                 'ab' => 'ab',
-            ),
-            'b' => array(
-                'ba' => (object) array(
+            ],
+            'b' => [
+                'ba' => (object)[
                     'baa' => 'baa',
                     'bab' => 'bab',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     public function testGetSetValue() {
         $gs = new GetterSetter();
         $dataObj = $this->getData();
 
-        $dataObj2 = $gs->setValue($dataObj, 'c', array('ca' => 'ca'));
+        $dataObj2 = $gs->setValue($dataObj, 'c', ['ca' => 'ca']);
         $this->assertEquals($dataObj2, $dataObj);
 
         $gs->set($dataObj, 'a.a', 'a.a');
-        $gs->setValueByArrayPath($dataObj, array('a','c'), 'a.c');
+        $gs->setValueByArrayPath($dataObj, ['a', 'c'], 'a.c');
         $this->assertEquals('a.a', $gs->get($dataObj, 'a.a'));
         $this->assertEquals('a.c', $gs->get($dataObj, 'a.c'));
-        $this->assertEquals(null, $gs->getValueByArrayPath($dataObj, array('a','b')));
-        $this->assertEquals('ab', $gs->getValueByArrayPath($dataObj, array('a','ab')));
-        $this->assertEquals('a.c', $gs->getValueByArrayPath($dataObj, array('a','c')));
+        $this->assertEquals(null, $gs->getValueByArrayPath($dataObj, ['a', 'b']));
+        $this->assertEquals('ab', $gs->getValueByArrayPath($dataObj, ['a', 'ab']));
+        $this->assertEquals('a.c', $gs->getValueByArrayPath($dataObj, ['a', 'c']));
 
         $this->assertEquals($dataObj->b, $gs->getValue($dataObj, 'b'));
     }

--- a/test/MagicAccessGetTestClass.php
+++ b/test/MagicAccessGetTestClass.php
@@ -9,9 +9,10 @@
 namespace Revinate\GetterSetter\test;
 
 
-class MagicAccessGetTestClass {
+class MagicAccessGetTestClass
+{
 
-    protected $values = array();
+    protected $values = [];
 
     /**
      * is utilized for reading data from inaccessible members.
@@ -20,11 +21,8 @@ class MagicAccessGetTestClass {
      * @return mixed
      * @link http://php.net/manual/en/language.oop5.overloading.php#language.oop5.overloading.members
      */
-    function __get($name) {
-        if (isset($this->values[$name])) {
-            return $this->values[$name];
-        }
-        return null;
+    public function __get($name) {
+        return $this->values[$name] ?? null;
     }
 
     /**
@@ -35,7 +33,7 @@ class MagicAccessGetTestClass {
      * @return void
      * @link http://php.net/manual/en/language.oop5.overloading.php#language.oop5.overloading.members
      */
-    function __set($name, $value) {
+    public function __set($name, $value) {
         $this->values[$name] = $value;
     }
 

--- a/test/MagicAccessTestClass.php
+++ b/test/MagicAccessTestClass.php
@@ -12,9 +12,10 @@ namespace Revinate\GetterSetter\test;
  * Class MagicAccessTestClass
  * @package Revinate\GetterSetter\test
  */
-class MagicAccessTestClass {
+class MagicAccessTestClass
+{
 
-    protected $values = array();
+    protected $values = [];
 
     /**
      * is utilized for reading data from inaccessible members.
@@ -23,7 +24,7 @@ class MagicAccessTestClass {
      * @return mixed
      * @link http://php.net/manual/en/language.oop5.overloading.php#language.oop5.overloading.members
      */
-    function __get($name) {
+    public function __get($name) {
         return $this->values[$name];
     }
 
@@ -34,7 +35,7 @@ class MagicAccessTestClass {
      * @return bool
      * @link http://php.net/manual/en/language.oop5.overloading.php#language.oop5.overloading.members
      */
-    function __isset($name) {
+    public function __isset($name) {
         return isset($this->values[$name]);
     }
 
@@ -47,7 +48,7 @@ class MagicAccessTestClass {
      * @return void
      * @link http://php.net/manual/en/language.oop5.overloading.php#language.oop5.overloading.members
      */
-    function __set($name, $value) {
+    public function __set($name, $value) {
         $this->values[$name] = $value;
     }
 

--- a/test/SetFunctionsTest.php
+++ b/test/SetFunctionsTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php /** @noinspection PhpUnhandledExceptionInspection */
+
 /**
  * Created by PhpStorm.
  * User: jasondent
@@ -8,69 +9,66 @@
 
 namespace Revinate\GetterSetter\test;
 
+use PHPUnit\Framework\TestCase;
 use Revinate\GetterSetter as gs;
 
 /**
  * Class TestSetFunctions
  * @package Revinate\GetterSetter\test
  */
-class SetFunctionsTest extends \PHPUnit_Framework_TestCase {
+class SetFunctionsTest extends TestCase
+{
 
     /**
      * @return array
      */
     public function providerSetters() {
-        return array(
-            array('isPublic',           false),
-            array('isProtected',        false),
-            array('isPrivate',          false),
-            array('isNotPrivate',       false),
-            array('isNotPublic',        false),
-            array('public',             'public_set'),
-            array('protected',          'protected_set'),
-            array('private',            'private_set'),
-            array('nullValue',          'null_set'),
-            array('nullValueProtected', 'null_set'),
-            array('methodGetterSetter', 'method_set'),
+        return [
+            ['isPublic', false],
+            ['isProtected', false],
+            ['isPrivate', false],
+            ['isNotPrivate', false],
+            ['isNotPublic', false],
+            ['public', 'public_set'],
+            ['protected', 'protected_set'],
+            ['private', 'private_set'],
+            ['nullValue', 'null_set'],
+            ['nullValueProtected', 'null_set'],
+            ['methodGetterSetter', 'method_set'],
 
             // test underscore
-            array('is_public',              false),
-            array('is_protected',           false),
-            array('is_private',             false),
-            array('is_not_private',         false),
-            array('is_not_public',          false),
-            array('null_value',             'null_set'),
-            array('null_value_protected',   'null_set'),
-            array('method_getter_setter',   'set_method'),
-            array('public_string_value',    'set_public_string_value'),
-            array('protected_string_value', 'set_protected_string_value'),
-            array('private_string_value',   'set_private_string_value'),
-        );
+            ['is_public', false],
+            ['is_protected', false],
+            ['is_private', false],
+            ['is_not_private', false],
+            ['is_not_public', false],
+            ['null_value', 'null_set'],
+            ['null_value_protected', 'null_set'],
+            ['method_getter_setter', 'set_method'],
+            ['public_string_value', 'set_public_string_value'],
+            ['protected_string_value', 'set_protected_string_value'],
+            ['private_string_value', 'set_private_string_value'],
+        ];
     }
 
     /**
      * @param $fieldName
      * @param $value
      * @dataProvider providerSetters
-     * @covers ::Revinate\GetterSetter\setValue
-     * @covers ::Revinate\GetterSetter\getValue
-     *
      */
     public function testSetValue($fieldName, $value) {
         $testClass = new AccessTestClass();
-        $notFound = (object) array();
+        $notFound = (object)[];
 
         $this->assertEquals($testClass, gs\setValue($testClass, $fieldName, $value), "Set Field: $fieldName");
-        $this->assertEquals($value, gs\getValue($testClass, $fieldName, $notFound),  "Validate Set Field: $fieldName");
+        $this->assertEquals($value, gs\getValue($testClass, $fieldName, $notFound), "Validate Set Field: $fieldName");
     }
 
     /**
      * @throws \Exception
-     * @covers ::Revinate\GetterSetter\setValue
-     * @covers ::Revinate\GetterSetter\getValue
      */
     public function testSetValueMagic() {
-        $notFound = (object) array();
+        $notFound = (object)[];
         $testClass = new MagicAccessTestClass();
 
         $this->assertEquals($notFound, gs\getValue($testClass, 'name', $notFound));
@@ -86,14 +84,17 @@ class SetFunctionsTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function providerNonObjects() {
-        return array(
-            array(1),
-            array(9.2),
-            array('hello'),
-            array(true),
-            array(false),
-            array(function(){}),
-        );
+        return [
+            [1],
+            [9.2],
+            ['hello'],
+            [true],
+            [false],
+            [
+                static function () {
+                }
+            ],
+        ];
     }
 
     /**
@@ -115,54 +116,54 @@ class SetFunctionsTest extends \PHPUnit_Framework_TestCase {
     }
 
     public function testSetNullField() {
-        $doc = array(
+        $doc = [
             'location' => null,
-            'info' => array(
+            'info' => [
                 'companyName' => null,
                 'address' => null,
                 'extra' => null,
-            ),
-        );
+            ],
+        ];
 
         $this->assertEquals(
-            array(
-                'location' => array('lat'=>55.6, 'lon'=>-0.6),
-                'info' => array(
+            [
+                'location' => ['lat' => 55.6, 'lon' => -0.6],
+                'info' => [
                     'companyName' => null,
                     'address' => null,
                     'extra' => null,
-                ),
-            ),
+                ],
+            ],
             gs\set(gs\set($doc, 'location.lat', 55.6), 'location.lon', -0.6)
         );
 
         $this->assertEquals(
-            array(
+            [
                 'location' => null,
-                'info' => array(
+                'info' => [
                     'companyName' => null,
                     'address' => null,
-                    'extra' => array(
-                        'level1' => array(
+                    'extra' => [
+                        'level1' => [
                             'level2' => 'level2',
-                        )
-                    ),
-                ),
-            ),
+                        ]
+                    ],
+                ],
+            ],
             gs\set($doc, 'info.extra.level1.level2', 'level2')
         );
     }
 
     public function testSetNull() {
         $this->assertEquals(
-            array(
-                'name'=>array('first'=>'Joe')
-            ),
+            [
+                'name' => ['first' => 'Joe']
+            ],
             gs\set(null, 'name.first', 'Joe')
         );
 
         $this->assertEquals(
-            array('name.first'=>'Joe'),
+            ['name.first' => 'Joe'],
             gs\setValue(null, 'name.first', 'Joe')
         );
     }

--- a/test/TestExamples.php
+++ b/test/TestExamples.php
@@ -8,9 +8,11 @@
 
 namespace Revinate\GetterSetter\test;
 
+use PHPUnit\Framework\TestCase;
 use Revinate\GetterSetter as gs;
 
-class TestExamples extends \PHPUnit_Framework_TestCase {
+class TestExamples extends TestCase
+{
     public function testExampleJson() {
         $json = '{"name":"example","type":"json","value":22}';
         $data = json_decode($json);
@@ -21,13 +23,13 @@ class TestExamples extends \PHPUnit_Framework_TestCase {
     }
 
     public function testExampleArrayVsObject() {
-        $json      = '{"name":"example","type":"json","value":22}';
-        $object    = json_decode($json);
-        $array     = (array)$object;
+        $json = '{"name":"example","type":"json","value":22}';
+        $object = json_decode($json);
+        $array = (array)$object;
         // The object gets updated as well
         $newObject = gs\setValue($object, 'type', 'Object');
         // Only the new array contains the update.
-        $newArray  = gs\setValue($array, 'type', 'Array');
+        $newArray = gs\setValue($array, 'type', 'Array');
         $this->assertEquals($object, $newObject);
         $this->assertNotEquals($array, $newArray);
     }
@@ -45,7 +47,6 @@ class TestExamples extends \PHPUnit_Framework_TestCase {
     "profession":"Stone cutter"
 }
 JSON;
-
     }
 
 

--- a/test/UtilTest.php
+++ b/test/UtilTest.php
@@ -8,16 +8,18 @@
 
 namespace Revinate\GetterSetter\test;
 
-use Revinate\GetterSetter\util as util;
+use PHPUnit\Framework\TestCase;
+use Revinate\GetterSetter\util;
 
-class UtilTest extends \PHPUnit_Framework_TestCase {
+class UtilTest extends TestCase
+{
 
     public function providerTestCamel() {
-        return array(
-            array('FirstLetter', 'firstLetter'),
-            array('HelloThere', 'hello_there'),
-            array('NiceDay', 'nice day'),
-        );
+        return [
+            ['FirstLetter', 'firstLetter'],
+            ['HelloThere', 'hello_there'],
+            ['NiceDay', 'nice day'],
+        ];
     }
 
     /**


### PR DESCRIPTION
 - usage of array_key_exists on objects is deprecated used `property_exists` instead.

 - ceased support for PHP < 7

 - code style PSR12